### PR TITLE
Remove interactive flags from docker build steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: navbuild nav carbon-cache graphite-web
 
 navbuild:
 	docker build -f Dockerfile.build -t "$(BUILDIMAGE)" .
-	docker run -ti --rm -v "$(CURDIR):/source" -v "$(HOME)/.cache/pip:/.cache/pip" --cap-drop=all -u "$(uid)" "$(BUILDIMAGE)"
+	docker run --rm -v "$(CURDIR):/source" -v "$(HOME)/.cache/pip:/.cache/pip" --cap-drop=all -u "$(uid)" "$(BUILDIMAGE)"
 
 nav:
 	docker build -t $(REPO)/nav .


### PR DESCRIPTION
This fails builds when running Make from automation. This makes the app more compatible.