### PR TITLE
Set Postgres version to 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - nav-variables.env
 
   postgres:
-    image: "postgres:9.4"
+    image: "postgres:12"
     volumes:
       - postgres:/var/lib/postgresql/data:Z
 


### PR DESCRIPTION
Postgres 9.4 is end of support. Upgrade to '12' which is as of 2020-01 is the 'latest' version. I've been running this version in prod for a while without seeing any problems. 