### PR TITLE
add restart stanza for all containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,16 +23,19 @@ services:
       - NOINITDB=0
     env_file:
       - nav-variables.env
+    restart: always
 
   postgres:
     image: "postgres:9.4"
     volumes:
       - postgres:/var/lib/postgresql/data:Z
+    restart: always
 
   carbon-cache:
     build: ./carbon-cache
     volumes:
       - whisper:/var/lib/graphite/storage/whisper:z
+    restart: always
 
   graphite-web:
     build: ./graphite-web
@@ -44,6 +47,7 @@ services:
       - CARBONLINK_HOSTS=carbon-cache:7002
     volumes:
       - whisper:/var/lib/graphite/storage/whisper:z
+    restart: always
 
 volumes:
   whisper:


### PR DESCRIPTION
There is no restart policy defined for the containers, and hence: 

_https://docs.docker.com/compose/compose-file/#restart
no is the default restart policy, and it does not restart a container under any circumstance. When always is specified, the container always restarts. The on-failure policy restarts a container if the exit code indicates an on-failure error._

I think 'always' sounds reasonable in a production environment. 