### PR TITLE
increase docker compose syntax version to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.5'
 services:
   nav:
     build: .


### PR DESCRIPTION
Version 2 is quite old, bumping version to 3 looks reasonable.  

Version 3.5 because I ran into some performance problems related to docker not allocating enough shm memory for the Postgres container. 3.5 support setting shm_size which I believe others might benefit from if they run into similar performance problems. 

Version 3.5 requires docker 17.12.0+ that should be quite conservative in 2020.