### PR TITLE
conditionally copy database.sql to the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
 # Install python module dependencies, assuming they have already been made
 # available as wheels
 COPY nav/requirements/ /requirements
-COPY nav/requirements.txt /
+COPY nav/requirements.txt database.sq[l] /
 COPY .wheels/ /wheelhouse
 RUN pip3 install --no-index --find-links=/wheelhouse -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ be supplied as environment variables:
 ## Using an existing database dump
 
 If you wish to bootstrap your NAV installation from an existing database dump
-(made from the `navpgdump` program), you can do so by mounting the dump file to
-the nav container as `/database.sql`. The database will be initialized with this
+(made from the `navpgdump` program), you can do so by saving the dump as 
+`database.sql`. The database will be initialized with this
 as the baseline the first time the container is started.
 
 ## Ideas for future improvement


### PR DESCRIPTION
Conditionally copy the file 'database.sql' to the container, if the file exists.  This approach seems a bit easier to perform than mounting the dump file to the nav container as /database.sql. 

