### PR TITLE
Set up the PostgreSQL container with a required password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - PGHOST=postgres
       - PGDATABASE=nav
       - PGUSER=nav
+      - PGPASSWORD=s3cret
       - PGPORT=5432
       - CARBONHOST=carbon-cache
       - CARBONPORT=2003
@@ -33,6 +34,11 @@ services:
     image: "postgres:12"
     volumes:
       - postgres:/var/lib/postgresql/data:Z
+    # The following vars are documented at https://hub.docker.com/_/postgres
+    environment:
+      - POSTGRES_PASSWORD=s3cret
+      - POSTGRES_USER=nav
+      - POSTGRES_DB=nav
     restart: always
 
   carbon-cache:

--- a/docker-initdb.sh
+++ b/docker-initdb.sh
@@ -27,7 +27,7 @@ EOF
 
 if [ "${NOINITDB}" -eq 0 ]; then
    export PGHOST="$HOST"
-   export PGUSER="postgres"
+   export PGUSER="$USER"
    export PGDATABASE="$DB"
    export PGPORT="$PORT"
    export PGPASSWORD="$PASSWORD"


### PR DESCRIPTION
Because:
- Apparently, newer Postgres images from the DockerHub require a POSTGRES_PASSWORD environment variable to start up from scratch.
- ecadd7781e0d648905dc70df0504ec3dd0494dc8  (#7) changed the Postgres image version to 12, thereby introducing this problem.

Older versions of the postgres image would use trust authentication within the local docker network. Not so anymore, unless specifically specified. This is still no safer than the old way of doing it, since we are using passwords in the clear here. However, it remains safe enough as long as only the containers in this Docker Compose project can access the postgres container.