### PR TITLE
install postgresql-client-12 from Postgresql.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,15 @@ RUN apt-get update \
        libapache2-mod-wsgi-py3 \
        nbtscan \
        libpq5 \
-       postgresql-client \
        python3-gammu
 
-# possibly want these packages for debugging inside the container:
-#       vim \
-#       less \
+# As Debian has no postgres-12 client, fetch it from Postgresql.org instead
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN wget  https://www.postgresql.org/media/keys/ACCC4CF8.asc -O /tmp/ACCC4CF8.asc \
+	&& apt-key add /tmp/ACCC4CF8.asc \
+	&& apt-get update \ 
+	&& apt-get -y install postgresql-client-12 \
+	&& rm /tmp/ACCC4CF8.asc
 
 
 # Install python module dependencies, assuming they have already been made


### PR DESCRIPTION
Proposal for how to install postgres-client-12 in the main NAV container. 
Based upon 
https://www.postgresql.org/download/linux/debian/

You might shorten it down a few commands by using | instead of &&, but with the latter you'll at least have some rudimentary error checking as && implies that the following command succeeded.   

Debian version being hard-coded to 'strech' twice, not as a variable.


