### PR TITLE
Switch to bullseye slim images to reduce container sizes

### DIFF
--- a/carbon-cache/Dockerfile
+++ b/carbon-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-slim
 LABEL description="A carbon-cache instance configured explicitly for use with NAV"
 LABEL maintainer="Morten Brekkevold <morten.brekkevold@sikt.no>"
 

--- a/graphite-web/Dockerfile
+++ b/graphite-web/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-slim
 LABEL description="A graphite-web instance for NAV"
 LABEL maintainer="Morten Brekkevold <morten.brekkevold@sikt.no>"
 


### PR DESCRIPTION
No need to run the full bullseye images, when the slim ones does the job. A listing of the current base images:
```
docker.io/library/python              3.9-slim-bullseye  0d5c5ad3da3d  7 days ago     130 MB
docker.io/library/python              3.9-bullseye       0a3ee4bd701a  7 days ago     939 MB
docker.io/library/debian              bullseye-slim      9f61210833de  2 weeks ago    84 MB
docker.io/library/debian              bullseye           5c8936e57a38  2 weeks ago    129 MB
```

Old bullseye containers:
```
localhost/nav-container_graphite-web  latest             6f37fd93bef6  About a minute ago  401 MB
localhost/nav-container_carbon-cache  latest             9dbcd05083ec  About a minute ago  221 MB
localhost/nav-container_nav           latest             8668f7670fa2  43 minutes ago      1.43 GB
```

New slim bullseye containers:
```
localhost/nav-container_graphite-web  latest             e8527f993c4c  2 minutes ago  298 MB
localhost/nav-container_carbon-cache  latest             fa2ce8b54c15  3 minutes ago  174 MB
localhost/nav-container_nav           latest             33930884db30  6 seconds ago  665 MB
```