### PR TITLE
Update container to NAV 5.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,9 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
        # Enable us to build the python-gammu module \
        libgammu-dev \
        # No git in slim image \
-       git
+       git \
+       # Need NodeJS/npm to build static web resources \
+       npm
 
 # Build wheels from requirements so they can be re-used in a production image
 # without installing all the dev tools there too
@@ -49,6 +51,7 @@ ARG NAV_VERSION
 RUN git clone https://github.com/Uninett/nav.git nav --branch ${NAV_VERSION} --depth 1
 RUN mkdir -p .wheels
 RUN --mount=type=cache,target=/root/.cache/pip pip3 wheel -w ./.wheels/ -r nav/requirements.txt -c nav/constraints.txt python-gammu==3.2.4
+RUN cd ./nav; make sassbuild
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --root="/source/.build" ./nav
 
 # Now, build the actual installation stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim-bullseye AS builder
-ENV REPO deb.debian.org
-ENV GIT_COMMITTER_NAME Dummy
-ENV GIT_COMMITTER_EMAIL dummy@example.org
+ENV REPO=deb.debian.org
+ENV GIT_COMMITTER_NAME=Dummy
+ENV GIT_COMMITTER_EMAIL=dummy@example.org
 # We need source archives as well
 RUN echo "\n\
 \
@@ -105,10 +105,10 @@ RUN a2dissite 000-default; a2ensite nav-site
 CMD ["/usr/bin/supervisord", "-n"]
 
 # Final environment
-ENV    PATH /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-ENV    ADMIN_MAIL root@localhost
-ENV    DEFAULT_FROM_EMAIL nav@localhost
-ENV    DOMAIN_SUFFIX .example.org
+ENV    PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+ENV    ADMIN_MAIL=root@localhost
+ENV    DEFAULT_FROM_EMAIL=nav@localhost
+ENV    DOMAIN_SUFFIX=.example.org
 
 VOLUME ["/var/log/nav", "/var/lib/nav/uploads/images/rooms"]
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 wheel -w ./.wheels/ -r nav/r
 RUN cd ./nav; make sassbuild
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --root="/source/.build" ./nav
 
-# Now, build the actual installation stage
+############################################
+# Now, build the actual installation stage #
+############################################
 FROM python:3.11-slim-bookworm
 
 # We're using mount caches, so don't clean the apt cache after every apt command!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM python:3.9-slim-bullseye AS builder
+FROM python:3.11-slim-bookworm AS builder
 ENV REPO=deb.debian.org
 ENV GIT_COMMITTER_NAME=Dummy
 ENV GIT_COMMITTER_EMAIL=dummy@example.org
 # We need source archives as well
 RUN echo "\n\
 \
-deb http://security.debian.org/ bullseye-security main contrib non-free\n\
-deb-src http://security.debian.org/ bullseye-security main contrib non-free\n\
-deb http://$REPO/debian bullseye main contrib non-free\n\
-deb-src http://$REPO/debian bullseye main contrib non-free\n\
-deb http://$REPO/debian bullseye-updates main contrib non-free\n\
-deb-src http://$REPO/debian bullseye-updates main contrib non-free\n\
-deb http://deb.debian.org/debian bullseye-backports main contrib non-free\n\
+deb http://security.debian.org/ bookworm-security main contrib non-free\n\
+deb-src http://security.debian.org/ bookworm-security main contrib non-free\n\
+deb http://$REPO/debian bookworm main contrib non-free\n\
+deb-src http://$REPO/debian bookworm main contrib non-free\n\
+deb http://$REPO/debian bookworm-updates main contrib non-free\n\
+deb-src http://$REPO/debian bookworm-updates main contrib non-free\n\
 " > /etc/apt/sources.list
 
 # Unfortunately, we need heaps of stuff just to build the docs, since autodoc
@@ -48,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 wheel -w ./.wheels/ -r nav/r
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --root="/source/.build" ./nav
 
 # Now, build the actual installation stage
-FROM python:3.9-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ you can explicitly build a specific NAV version by adding a build argument,
 like this:
 
 ```
-docker-compose build --build-arg NAV_VERSION=5.8.2 nav
+docker-compose build --build-arg NAV_VERSION=5.13.2 nav
 docker-compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   nav:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        NAV_VERSION: 5.8.2
+        NAV_VERSION: 5.13.2
     ports:
       - "80:80"
       - "162:162/udp"

--- a/etc/apache2/sites-available/nav-site.conf
+++ b/etc/apache2/sites-available/nav-site.conf
@@ -4,7 +4,7 @@
     Define document_root /var/lib/nav/htdocs
     Define documentation_path /var/lib/nav/htdocs/doc
     Define nav_uploads_path /var/lib/nav/uploads
-    Define nav_python_base /usr/local/lib/python3.9/site-packages
+    Define nav_python_base /usr/local/lib/python3.11/site-packages
     # Define nav_virtual_env /path/to/a/python/virtual/env/with/NAV/in/it
     Define nav_user nav
 

--- a/etc/supervisor/conf.d/nav.conf
+++ b/etc/supervisor/conf.d/nav.conf
@@ -1,5 +1,5 @@
 [program:alertengine]
-command=/usr/local/bin/alertengine.py -f
+command=/usr/local/bin/alertengine -f
 user=nav
 autorestart = true
 
@@ -14,21 +14,21 @@ user=nav
 autorestart = true
 
 [program:pping]
-command=/usr/local/bin/pping.py -f
+command=/usr/local/bin/pping -f
 user=root
 autorestart = true
 
 [program:servicemon]
-command=/usr/local/bin/servicemon.py -f
+command=/usr/local/bin/servicemon -f
 user=nav
 autorestart = true
 
 [program:smsd]
-command=/usr/local/bin/smsd.py -f
+command=/usr/local/bin/smsd -f
 user=nav
 autorestart = true
 
 [program:snmptrapd]
-command=/usr/local/bin/snmptrapd.py -f
+command=/usr/local/bin/navtrapd -f
 user=root
 autorestart = true


### PR DESCRIPTION
The container definition had fallen behind.  It was stuck on NAV 5.8, while the current NAV version is 5.13.

This modernizes the `Dockerfile` syntax slightly, and updates the main NAV container to use Debian Bookworm, Python 3.11 and NAV 5.13.

Fixes #26 