### PR TITLE
Upgrade postgresql to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: always
 
   postgres:
-    image: "docker.io/postgres:12"
+    image: "docker.io/postgres:16"
     volumes:
       - postgres:/var/lib/postgresql/data:Z
     # The following vars are documented at https://hub.docker.com/_/postgres


### PR DESCRIPTION
I tried 17, but it did not work - most likely because the PostgreSQL clients in the nav and graphite containers are too old, and upgrading these is a lot more work, so we'll leave it for later.

Fixes #28 